### PR TITLE
Added Mocking section to Azure.Core readme

### DIFF
--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -100,6 +100,38 @@ public async Task UsingResponseOfT()
 }
 ```
 
+### Mocking
+One of the most important cross-cutting features of our new client libraries using Azure.Core is that they are designed for mocking. 
+Mocking is enabled by:
+
+- providing a protected parameterless constructor on client types.
+- making service methods virtual.
+- providing APIs for constructing model types returned from virtual service methods. To find these factory methods look for types with the _ModelFactory_ suffix, e.g. `ConfigurationClientModelFactory`.
+
+For example, the ConfigurationClient.Get method can be mocked (with [Moq](https://github.com/moq/moq4)) as follows:
+
+```c#
+// Create a mock response
+var mockResponse = new Mock<Response>();
+
+// Create a client mock
+var mock = new Mock<ConfigurationClient>();
+
+// Setup client method
+mock.Setup(c => 
+    c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+    .Returns(new Response<ConfigurationSetting>(mockResponse.Object, 
+         // factory for the model type
+         ConfigurationClientModelFactory.ConfigurationSetting("Key", "Value")
+    )
+);
+
+// Use the client mock
+ConfigurationClient client = mock.Object;
+ConfigurationSetting setting = client.Get("Key");
+Assert.AreEqual("Value", setting.Value);
+```
+
 ### Reporting Errors ```RequestFailedException```
 Coming soon ...
 
@@ -109,5 +141,4 @@ Coming soon ...
 ### Consuming Long Running Operations Using ```Operation<T>```
 Comming soon ...
 
-### Mocking
-Comming soon ...
+


### PR DESCRIPTION
This section is a bit not like the other (as mocking does not depend on Azure.Core features), but it is a cross-cutting aspect of our Track 2 libraries, so I included it here.